### PR TITLE
make h12.me the canonical import path

### DIFF
--- a/examples/main.go
+++ b/examples/main.go
@@ -6,10 +6,11 @@ package main
 
 import (
 	"fmt"
-	"github.com/hailiang/html-query"
-	. "github.com/hailiang/html-query/expr"
 	"io"
 	"net/http"
+
+	"h12.me/html-query"
+	. "h12.me/html-query/expr"
 )
 
 func main() {

--- a/expr/checker.go
+++ b/expr/checker.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package expr
+package expr // import "h12.me/html-query/expr"
 
 import (
 	"regexp"

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -17,7 +17,7 @@ func (spec *Spec) GenerateExpr() {
 	file := "output/auto_expr.go"
 	f, err := os.Create(file)
 	c(err)
-	fp(f, "package expr")
+	fp(f, `package expr // import "h12.me/html-query/expr"`)
 	fp(f, "import (")
 	fp(f, `"golang.org/x/net/html/atom"`)
 	fp(f, ")")

--- a/gen/spec.go
+++ b/gen/spec.go
@@ -5,13 +5,14 @@
 package main
 
 import (
-	"github.com/hailiang/html-query"
-	. "github.com/hailiang/html-query/expr"
 	"io"
 	"net/http"
 	"os"
 	"sort"
 	"strings"
+
+	"h12.me/html-query"
+	. "h12.me/html-query/expr"
 )
 
 const (

--- a/node.go
+++ b/node.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package query
+package query // import "h12.me/html-query"
 
 import (
 	"bytes"


### PR DESCRIPTION
Currently attempt to "go install -v ./..." produces errors like these:

```
examples/main.go:23: cannot use "github.com/hailiang/html-query/expr".Class("tags") (type "github.com/hailiang/html-query/expr".Checker) as type "h12.me/html-query/expr".Checker in argument to item.Span
# h12.me/html-query/gen
gen/spec.go:105: cannot use "github.com/hailiang/html-query/expr".CaptionText("List of attributes") (type "github.com/hailiang/html-query/expr".Checker) as type "h12.me/html-query/expr".Checker in argument to root.Table
```

Suggest to use h12.me as the canonical import path throughout all the imports, similar to http://godoc.org/h12.me/socks and analogous to the change in https://github.com/hailiang/socks/pull/4/files
