### PR TITLE
add link to GoDoc API and doc.go file with package description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 html-query: A fluent and functional approach to querying HTML DOM
 =================================================================
+[![GoDoc](https://godoc.org/h12.me/html-query?status.svg)](https://godoc.org/h12.me/html-query)
 
 html-query is a Go package that provides a fluent and functional interface for
 querying HTML DOM. It is based on [golang.org/x/net/html](https://godoc.org/golang.org/x/net/html).

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,9 @@
+// Copyright 2015, Hǎiliàng Wáng. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+/*
+Package query provides a fluent and functional interface
+for querying HTML DOM using Go. It is based on golang.org/x/net/html.
+*/
+package query


### PR DESCRIPTION
Having a link to the godoc page should give a hint to the user that they are supposed to use it under the vanity domain name.  See https://github.com/dmitris/html-query/tree/godoc for how the godoc button will look.

Having at least a summary description of the package in doc.go would make the package page look better on https://godoc.org/h12.me/html-query (will show a package description sentence before a long list of functions).  Feel free to modify or expand the package description if you want.
